### PR TITLE
Adopt Code of Conduct

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,74 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance, race,
+religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the CHAOSS Code of Conduct Team at coc@chaoss.community. All
+reported by contacting the CHAOSS Code of Conduct Team at <inclusion@chaoss.community>. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.
@@ -77,7 +77,7 @@ incidence reports. The CHAOSS Code of Conduct Team shall consist of four members
 two from each committee and at least two who are on the Governing Board.
 Members are elected by the community every two years or when needed.
 
-The CHAOSS Code of Conduct Team currently consists of:
+The following people comprise the CHAOSS Code of Conduct Team and are the only recipients of <inclusion@chaoss.community):
  - (To be elected from software committee and on governing board)
  - (To be elected from metric committee and on governing board)
  - (To be elected from software committee)
@@ -92,3 +92,15 @@ available at https://geekfeminism.org/about/code-of-conduct/
 
 [cc-homepage]: https://www.contributor-covenant.org
 [gf-homepage]: https://geekfeminism.org/
+
+## Version History
+
+* V1.0 adopted through a CHAOSS Governing Board vote from xx.xx.xxxx
+
+* v1.0 proposed on [January 27, 2018](https://github.com/chaoss/governance/pull/3#issuecomment-360939881) by the working group consisting of:
+    * Alexander Serebrenik
+    * Georg Link
+    * Jesus M Gonzales-Barahona
+    * Ray Paik
+    * Sean Goggins
+    * Vicky Janicki

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,4 +1,4 @@
-# Contributor Covenant Code of Conduct
+# CHAOSS Community: Code of Conduct
 
 ## Our Pledge
 
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
+reported by contacting the CHAOSS Governance Board at [INSERT EMAIL ADDRESS]. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.
@@ -65,10 +65,16 @@ Project maintainers who do not follow or enforce the Code of Conduct in good
 faith may face temporary or permanent repercussions as determined by other
 members of the project's leadership.
 
+We will respect confidentiality requests for the purpose of protecting victims of unacceptable behavior. At our discretion, we may publicly name a person about whom we’ve received unacceptable behavior complaints, or privately warn third parties about them, if we believe that doing so will increase the safety of CHAOSS members or the general public. We will not name victims without their affirmative consent.
+
+The CHAOSS Governance Board will report on a yearly basis the number of incidence reports. A this time, the Governance Board reviews the effectiveness of this Code of Conduct.
+
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+This Code of Conduct is adapted from the [Contributor Covenant][cc-homepage], version 1.4,
 available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+and the [Geek Feminism][gf-homepage] Code of Conduct,
+available at https://geekfeminism.org/about/code-of-conduct/
 
-[homepage]: https://www.contributor-covenant.org
-
+[cc-homepage]: https://www.contributor-covenant.org
+[gf-homepage]: https://geekfeminism.org/

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -97,7 +97,7 @@ available at https://geekfeminism.org/about/code-of-conduct/
 
 ## Version History
 
-* v1.0 adopted through a CHAOSS Governing Board vote from xx.xx.xxxx
+* v1.0 adopted through a CHAOSS Governing Board vote from February 12, 2018
 
 * v1.0 proposed on [January 27, 2018](https://github.com/chaoss/governance/pull/3#issuecomment-360939881) by the working group consisting of:
     * Alexander Serebrenik

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the CHAOSS Governance Board at [INSERT EMAIL ADDRESS]. All
+reported by contacting the CHAOSS Code of Conduct Team at coc@chaoss.community. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.
@@ -65,9 +65,23 @@ Project maintainers who do not follow or enforce the Code of Conduct in good
 faith may face temporary or permanent repercussions as determined by other
 members of the project's leadership.
 
-We will respect confidentiality requests for the purpose of protecting victims of unacceptable behavior. At our discretion, we may publicly name a person about whom we’ve received unacceptable behavior complaints, or privately warn third parties about them, if we believe that doing so will increase the safety of CHAOSS members or the general public. We will not name victims without their affirmative consent.
+We will respect confidentiality requests for the purpose of protecting victims
+of unacceptable behavior. At our discretion, we may publicly name a person about
+whom we’ve received unacceptable behavior complaints, or privately warn third
+parties about them, if we believe that doing so will increase the safety of
+CHAOSS members or the general public. We will not name victims without their
+affirmative consent.
 
-The CHAOSS Governance Board will report on a yearly basis the number of incidence reports. A this time, the Governance Board reviews the effectiveness of this Code of Conduct.
+The CHAOSS Code of Conduct Team will report on a yearly basis the number of
+incidence reports. The CHAOSS Code of Conduct Team shall consist of four members:
+two from each committee and at least two who are on the Governing Board.
+Members are elected by the community every two years or when needed.
+
+The CHAOSS Code of Conduct Team currently consists of:
+ - (To be elected from software committee and on governing board)
+ - (To be elected from metric committee and on governing board)
+ - (To be elected from software committee)
+ - (To be elected from metric committee)
 
 ## Attribution
 

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -97,7 +97,7 @@ available at https://geekfeminism.org/about/code-of-conduct/
 
 ## Version History
 
-* V1.0 adopted through a CHAOSS Governing Board vote from xx.xx.xxxx
+* v1.0 adopted through a CHAOSS Governing Board vote from xx.xx.xxxx
 
 * v1.0 proposed on [January 27, 2018](https://github.com/chaoss/governance/pull/3#issuecomment-360939881) by the working group consisting of:
     * Alexander Serebrenik

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -77,7 +77,9 @@ incidence reports. The CHAOSS Code of Conduct Team shall consist of four members
 two from each committee and at least two who are on the Governing Board.
 Members are elected by the community every two years or when needed.
 
-The following people comprise the CHAOSS Code of Conduct Team and are the only recipients of <inclusion@chaoss.community):
+## Who to Contact
+
+The following people comprise the CHAOSS Code of Conduct Team and are the only recipients of <inclusion@chaoss.community>:
  - (To be elected from software committee and on governing board)
  - (To be elected from metric committee and on governing board)
  - (To be elected from software committee)


### PR DESCRIPTION
**IMPORTANT: Do not merge, until the CHAOSS Governance Board has formally adopted the Code of Conduct for the CHAOSS community.**

The Code of Conduct workgroup is finalizing the text of a Code of Conduct that will be proposed to the CHAOSS community.

The Contributor Covenant has most of our desired features and is the basis of our own Code of Conduct.

We added a paragraph from Geek Feminism about the reporting and consequences. (paragraph starting with "We will respect confidentiality")

We added a paragraph about reporting yearly incidence report numbers and reviewing the CoC. (paragraph starting with "The CHAOSS Governance Board will")