### PR TITLE
Community Handbook proposal

### DIFF
--- a/community-handbook/README.md
+++ b/community-handbook/README.md
@@ -1,0 +1,16 @@
+# Community Handbook
+
+The CHAOSS Community Handbook is a central repository for how we run the project. As part of our value of being transparent, the handbook is open to the world and we welcome feedback. Please make pull requests to suggest improvements or add clarifications. Please use issues to ask questions.
+
+## Table of Content
+
+TODO
+
+
+## Why handbook first
+
+Documenting in the handbook before taking an action may require more time initially because you have to think about where to make the change, integrate it with the existing content, and then possibly add to or refactor the handbook to have a proper foundation. But, it saves time in the long run, and this communication is essential to our ability to continue scaling and adapting our organization.
+
+This process is not unlike writing tests for your software. Only communicate a (proposed) change via a change to the handbook; don't use a presentation, email, chat message, or another medium to communicate the components of the change. These other forms of communication might be more convenient for the presenter, but they make it harder for the audience to understand the context and the implications for other potentially affected processes.
+
+Having a **"handbook first"** mentality ensures there is no duplication; the handbook is always up to date, and others are better able to contribute.

--- a/community-handbook/README.md
+++ b/community-handbook/README.md
@@ -1,4 +1,4 @@
-# Community Handbook
+# CHAOSS Community Handbook
 
 The CHAOSS Community Handbook is a central repository for how we run the project. As part of our value of being transparent, the handbook is open to the world and we welcome feedback. Please make pull requests to suggest improvements or add clarifications. Please use issues to ask questions.
 


### PR DESCRIPTION
I propose that CHAOSS starts documenting roles and processes in a handbook.

The goal is to have a central place for community members to learn about how CHAOSS operates. 
This should help with onboarding and aligning practices across committees and working groups.

The GitLab handbook served as an inspiration.
https://about.gitlab.com/handbook/