### PR TITLE
add DCO requirement to GSoC interest page

### DIFF
--- a/GSoC-interest.md
+++ b/GSoC-interest.md
@@ -6,7 +6,7 @@ A few details regarding the application process specific to the CHAOSS project:
 
 1) You must complete one micro-task related to the idea you are interested in. You can find the micro-tasks on the GSoc Idea Page at: [GSoC-Ideas.md](./GSoC-Ideas.md)
 
-2) Once you completed one micro-task, create a pull request on this file below to add yourself, your information, and a link to your repository of the completed micro-task.
+2) Once you completed one micro-task, create a pull request on this file below to add yourself, your information, and a link to your repository of the completed micro-task. **UPDATE:** This repository now requires [Developer Certificate of Origin](https://developercertificate.org/) (DCO) sign-off; see [issue #96](https://github.com/chaoss/governance/issues/96) for details on how to sign your commits.
 
 3) You are welcome to include in your repositories other information that could be of interest, such as open issues or pull requests submitted to the project to which you intend to contribute during GSoC, contributions to other projects, skills, and other related information.
 

--- a/GSoC-interest.md
+++ b/GSoC-interest.md
@@ -6,7 +6,7 @@ A few details regarding the application process specific to the CHAOSS project:
 
 1) You must complete one micro-task related to the idea you are interested in. You can find the micro-tasks on the GSoc Idea Page at: [GSoC-Ideas.md](./GSoC-Ideas.md)
 
-2) Once you completed one micro-task, create a pull request on this file below to add yourself, your information, and a link to your repository of the completed micro-task. **UPDATE:** This repository now requires [Developer Certificate of Origin](https://developercertificate.org/) (DCO) sign-off; see [issue #96](https://github.com/chaoss/governance/issues/96) for details on how to sign your commits.
+2) Once you completed one micro-task, create a pull request on this file below to add yourself, your information, and a link to your repository of the completed micro-task. **UPDATE:** This repository now requires [Developer Certificate of Origin](https://developercertificate.org/) (DCO) sign-off; see [CONTRIBUTING.md](https://github.com/chaoss/governance/blob/master/CONTRIBUTING.md#code-or-document-change-contributions-github-interface) for details on how to sign your commits.
 
 3) You are welcome to include in your repositories other information that could be of interest, such as open issues or pull requests submitted to the project to which you intend to contribute during GSoC, contributions to other projects, skills, and other related information.
 


### PR DESCRIPTION
This pull request adds a notice to the GSoC interest page to inform students that they are required to include a DCO signoff.