### PR TITLE
add handbook page for chaosscon

### DIFF
--- a/community-handbook/README.md
+++ b/community-handbook/README.md
@@ -8,3 +8,4 @@ If you are interested in helping with the community handbook, [#105](https://git
 
 * [General](./)
   - [Handbook Usage](./handbook-usage.md)
+* [CHAOSScon](./chaosscon.md)

--- a/community-handbook/chaosscon.md
+++ b/community-handbook/chaosscon.md
@@ -1,0 +1,165 @@
+# CHAOSScon
+
+
+# Form organizing committee 
+
+CHAOSScon is a community organized event. We do not have dedicated event staff and rely on volunteers. 
+
+A combination of methods can be used to ask for volunteers:
+
+
+
+*   CHAOSS general mailing list
+*   CHAOSS events mailing list
+*   Weekly meetings
+*   Reach out directly to individuals
+
+A good organizing committee has volunteers with different skills and interests. The following sections detail what needs to be done to organize CHAOSScon. An organizing committee of about 7-10 volunteers has been effective in executing all tasks.
+
+
+# Secure venue
+
+What venue we use depends on when and where we plan CHAOSScon.
+
+CHAOSScon North America (NA) should be co-located with the Linux Foundation’s Open Source Summit North America (OSSNA). CHAOSScon can share the same venue. To secure the venue, we need to file a request on the OSSNA website or contact someone from the LF events team.
+
+CHAOSScon Europe should be co-located with FOSDEM in Brussels Belgium. Bitergia has secured a venue in the past. 
+
+The organizing committee can determine how many rooms they want to use. A second room can be used for socializing and workshops.
+
+
+# Time for CHAOSScon 
+
+It is easier to end the event earlier than run late.
+
+Consider other events that are happening on the same day.
+
+
+# Release and advertise CFP 
+
+The Call for Participation (CfP) invites speakers to submit topics for talks, workshops, or tutorials. 
+
+We can re-use the same CFP from the last CHAOSScon. CFP’s are stored on GitHub in the [chaoss/website repository](https://github.com/chaoss/website/tree/master/CHAOSScon) and can be retrieved by looking at older versions of files.
+
+The form for speakers to submit talks is a Google form. E.g. [CFP for CHAOSSconNA’19](https://docs.google.com/forms/d/1MKb39UHpsrDydRjSRwRjEeQNywFeNckvjSfpJtUUfkY/edit)
+
+
+# Find sponsors
+
+We have a [funding prospectus](https://github.com/chaoss/website/blob/master/CHAOSScon/2019NA/CHAOSSconNA19_funding_prospectus.docx) that needs to be updated.
+
+Share sponsor prospectus:
+
+
+
+*   Mailing list
+*   Twitter
+*   Specific people the organizing committee knows
+
+Work with sponsors to fulfil promises to sponsors.
+
+
+# Decide on Speakers
+
+When the CFP closes, we use a spreadsheet for evaluating submissions. Each submission gets a row in a table and each organizing committee member gets a column to insert +1, 0, or -1 to vote on submissions. The sum of votes is the basis for discussion.
+
+During a committee meeting, the spreadsheet with submissions and votes is reviewed. Topics and speakers are selected. Based on the selection, a schedule is assembled. 
+
+A person selects the action item to inform speakers and confirm their participation. 
+
+
+## Keynotes 
+
+Keynotes get more time than regular sessions.
+
+Keynote speakers should have a message that we as a community want to elevante. We either invite keynote speakers or we ask if a CFP submitter would be willing to extend their talk to a keynote.
+
+
+# Launch registration page 
+
+For CHAOSScon North America, we like to partner with the Linux Foundation to have CHAOSScon be an option for registrations to Open Source Summit North America. The Linux Foundation can also provide a stand-alone registration for CHAOSScon only. The latter is the form we link to from the CHAOSScon website.
+
+For CHAOSScon Europe, we used Eventbrite.
+
+
+# Release and advertise schedule
+
+The CFP has a date for releasing the conference schedule. On that date, the schedule contains all speakers that confirmed. Speakers who have not confirmed yet will be added later or left off the schedule.
+
+The schedule is added to the website by updating the corresponding markdown page [on GitHub](https://github.com/chaoss/website/tree/master/CHAOSScon).
+
+To advertise the schedule:
+
+*   Send message to CHAOSS mailing list, ask everyone to spread the news
+*   Post regular messages on Twitter
+*   Reach out to individuals who expressed interest in CHAOSScon
+
+
+# Confirm catering
+
+We typically have coffee, tea, and snacks at CHAOSScon for breaks.
+
+
+# Print name tags
+
+Make sure to have name tags at CHAOSScon. 
+
+When co-locating with Linux Foundation events and using their registration system, the LF will provide name tags (i.e., lanyards).
+
+
+# Determine Master of Ceremony
+
+The Master of Ceremony (MC) is responsible for:
+
+
+
+*   welcoming atendees
+*   announcing schedule
+*   work with speakers to make sure they get set up with their laptops
+*   keep everyone on schedule
+*   adjourn the meeting
+
+
+# Upload Presentation Slides 
+
+In the week before CHAOSScon, email all presenters to ask them for their slides. Ideally, all slides are uploaded to the conference page before the event starts. Some presenters prefer to work on slides last minute and provide them on the morning of the event. We need someone at the event who can accept USB sticks and will upload the slides to the website.
+
+On the conference website, links to slides are added in a column of the schedule. The slides are uploaded, ideally as PDFs, to GitHub. The chaoss/website repo is setup to produce a URL that can be linked to.
+
+
+    File: [https://github.com/chaoss/website/blob/master/CHAOSScon/2019EU/slides/GMD-tutorial.pdf](https://github.com/chaoss/website/blob/master/CHAOSScon/2019EU/slides/GMD-tutorial.pdf)
+
+
+    URL for website: [https://chaoss.github.io/website/CHAOSScon/2019EU/slides/GMD-tutorial.pdf](https://chaoss.github.io/website/CHAOSScon/2019EU/slides/GMD-tutorial.pdf) 
+
+
+# Prepare venue
+
+In preparation for CHAOSScon, work with venue to:
+
+
+
+*   Print the schedule to post it at the venue
+*   Print signs with the hashtag for the event
+*   Print arrow signs, in case we need to direct attendees to the right room
+
+On day of event (check with venue what is allowed):
+
+
+
+*   Hang up schedule and hashtag signs
+*   Set up a table to give out name tags
+*   Provide a place for sponsors to put swag
+*   Set up video recording
+
+
+# Video-tape talks
+
+We like to record presentations and upload them to the CHAOSS YouTube channel. This increases the range for presenters and creates an archive to reference talks. 
+
+The University of Nebraska at Omaha has in the past brought a camcorder, processed the videos, and uploaded them.
+
+
+# Follow-up
+
+After the event, thank speakers, share link to videos, ...


### PR DESCRIPTION
The handbook page for organizing CHAOSScon was initially drafted back in May (https://github.com/chaoss/governance/issues/105#issuecomment-491045895). I made small changes to it, but it would be much easier if we commit it to the handbook and then improve it there.

This PR is to get an initial version added to the handbook.