### PR TITLE
Add Roles and Responsibilities to Handbook

### DIFF
--- a/community-handbook/README.md
+++ b/community-handbook/README.md
@@ -8,4 +8,5 @@ If you are interested in helping with the community handbook, [#105](https://git
 
 * [General](./)
   - [Handbook Usage](./handbook-usage.md)
+  - [Roles and Responsibilities in the Community](./roles-responsibilities.md)
 * [CHAOSScon](./chaosscon.md)

--- a/community-handbook/roles-responsibilities.md
+++ b/community-handbook/roles-responsibilities.md
@@ -1,0 +1,100 @@
+# CHAOSS roles and responsibilities
+
+## Repository Maintainer
+* Send reminder about meetings
+* Prepare meetings
+* Lead meetings
+* Make sure meeting minutes are kept
+* Facilitate creation and advancement of metrics/software
+* Answer questions about history of working group and metrics/software
+* Coordinate with other working groups on metrics/software
+* Report on weekly community call progress in working group
+* Submit working group related topics to conferences
+* Review issues on repository
+* Review and merge pull requests
+* Regularly check repository for stale content
+* Coordinate metrics release for working group
+* monitor issue tracker and pull requests
+* steer the architecture of the metrics/software
+
+## CHAOSScon organizing committee member
+* Regularly review status of planning progress
+* Secure venue for event
+* Secure catering for event
+* Set up CFP for event
+* Promote CFP for event
+* Review CFP submissions and select talks
+* Build an agenda for event
+* Coordinate with speakers that they are coming
+* Collect and upload slides from speakers
+* Make sure we have signage at event
+* Secure funding from sponsors
+* Create and update conference website
+* Edit recordings from CHAOSScon sessions and upload them to YouTube
+
+## CHAOSS Governing Board Member
+* Consider the high-level strategy for the CHAOSS project
+* Participate in board meetings (~4 meetings per year) and vote on proposals.
+* Participate in email votes if called (outside of board meetings).  
+* Represent concerns of community members at board meetings. 
+* Attend monthly meetings to stay up to date with what is happening
+* Spread the word about CHAOSS, e.g., present at conferences.  
+* Be a representative of the CHAOSS project. 
+
+## CHAOSS Board Co-Lead
+* Invite to board meetings
+* Prepare board meetings
+* Attend and participate in board meetings
+* Advance and execute community strategy 
+* Maintain communication with Linux Foundation
+* Regularly review and update governance documents
+* Provide guidance to community members and working groups
+
+## CHAOSS metrics release collaborator
+* Review metrics release spreadsheet
+* Coordinate with working groups to confirm status of metrics
+* Double-check formatting on metrics
+* Create release notes
+* Tag release in working group repositories
+* Create release pages on website
+* Create a PDF of released metrics
+
+## Editor of CHAOSSweekly
+* Collect themes from a week in CHAOSS community - attend several meetings, especially community call
+* Write a summary of what is happening in CHAOSS community 
+* Update the dates of upcoming meetings
+* Send CHAOSSweekly to mailing list
+
+## Mailing list moderator
+* When moderation request comes in, react to it
+
+## Twitter Manager
+* Like and re-tweet tweets about @CHAOSSproj that are relevant
+* Share status updates from @CHAOSSproj
+* Promote CHAOSS events
+
+## Code of Conduct Enforcement Team member
+(luckily we have had no reports yet)
+* monitor mailing list to which reports can be made
+* respond to reports
+
+## Mentor (e.g., GSoC or Outreachy)
+* Submit project ideas 
+* Respond to interested students 
+* Regularly meet with accepted mentees
+* Help mentees get started with the CHAOSS project and technologies
+* Report to the CHAOSS community how things are going with the mentees
+
+
+## Software Developer
+* post ideas for new features as issues 
+* create pull requests for code changes
+* respond to reviews from maintainers on pull requests
+
+## New Member
+* Attend community and workgroup meetings
+* Register for mailing lists
+* Try to find ways to help
+* Catch up on GitHub and other tools used by CHAOSS
+* See how you can align what you do elsewhere with what goes on in CHAOSS
+* Ask questions about CHAOSS and what is being worked on


### PR DESCRIPTION
We had an [email about Succession Planning on the mailing list](https://lists.linuxfoundation.org/pipermail/chaoss/2020-February/001083.html) and discussed it further on the weekly call 2020-02-25, extending the list of [roles and responsibilities in a google doc](https://docs.google.com/document/d/1UWop73-e8d9m_gv3P5LmB2ybe_eJri-HHiUKGrIuZzc/edit?usp=sharing). 

This PR adds that list to our handbook. It is not intended to be complete and is expected to change over time. Adding it to the handbook gives us something to refer to and to improve.

