### PR TITLE
Changing "software developer" to "Contributor"

### DIFF
--- a/community-handbook/roles-responsibilities.md
+++ b/community-handbook/roles-responsibilities.md
@@ -86,7 +86,7 @@
 * Report to the CHAOSS community how things are going with the mentees
 
 
-## Software Developer
+## Contributor
 * post ideas for new features as issues 
 * create pull requests for code changes
 * respond to reviews from maintainers on pull requests


### PR DESCRIPTION
Inside CHAOSS, most of the people who perform those tasks are not building software.