### PR TITLE
add disclaimer to Outreachy ideas page

### DIFF
--- a/Outreachy-ideas.md
+++ b/Outreachy-ideas.md
@@ -1,5 +1,7 @@
 # Ideas for Outreachy projects
 
+Please find accepted [ideas on the Outreachy website](https://www.outreachy.org/apply/project-selection/#chaoss). Below are the ideas CHAOSS members developed before submitting.
+
 ## Idea: Machine Learning for Anomaly Detection in Open Source Communities
 
 [ Micro-tasks and place for questions ](https://github.com/chaoss/augur/issues/545)


### PR DESCRIPTION
I believe Outreachy posts ideas on their website, unlike GSoC. This PR adds a disclaimer and link to Outreachy on the ideas page because I think we did not submit all of the ideas from our markdown file.