### PR TITLE
point to GSoC-interest.md

### DIFF
--- a/GSoC-Ideas.md
+++ b/GSoC-Ideas.md
@@ -1,6 +1,6 @@
 # Ideas for Google Summer of Code projects
 
-Interested in working with CHAOSS? Below are some project ideas. We describe how to apply to work with CHAOSS on a different page: https://github.com/chaoss/governance/blob/master/GSoC-interest.md
+Interested in working with CHAOSS? Below are some project ideas. We describe how to apply to work with CHAOSS and how we select students on a different page: https://github.com/chaoss/governance/blob/master/GSoC-interest.md
 
 
 ## Idea: Creating Quality models using GrimoireLab and CHAOSS metrics

--- a/GSoC-Ideas.md
+++ b/GSoC-Ideas.md
@@ -1,5 +1,7 @@
 # Ideas for Google Summer of Code projects
 
+Interested in working with CHAOSS? Below are some project ideas. We describe how to apply to work with CHAOSS on a different page: https://github.com/chaoss/governance/blob/master/GSoC-interest.md
+
 
 ## Idea: Creating Quality models using GrimoireLab and CHAOSS metrics
 


### PR DESCRIPTION
The GSoC website points only to the ideas. I have the impression that students are not finding the page where we are describing our selection process. This PR adds a link to the critical, important page that GSoC students need to know.