### PR TITLE
Add Community Report to Handbook

### DIFF
--- a/community-handbook/README.md
+++ b/community-handbook/README.md
@@ -11,6 +11,7 @@ If you are interested in helping with the community handbook, [#105](https://git
   - [Roles and Responsibilities in the Community](./roles-responsibilities.md)
 * [CHAOSScast](./chaosscast.md) - Community Podcast
 * [CHAOSScon](./chaosscon.md)
+* [Community Report](./community-report.md)
 * [Metrics Release](./metrics-release.md)
   - [Metrics Translations](./metrics-translations.md)
 * [Website](./website.md)

--- a/community-handbook/community-report.md
+++ b/community-handbook/community-report.md
@@ -18,7 +18,7 @@ The Communit Report processes have the following roles:
 
 ## Requesting a Community Report
 
-Anyone can fill out a form on the CHAOSS.community website. The form submits to a Linux Foundation system. 
+Anyone can fill out a form on the CHAOSS.community website. The form submits to a Linux Foundation system and the form is forwarded to essential CHAOSS community members for processing.
 
 ## Generating a Community Report
 
@@ -30,4 +30,3 @@ When the CHAOSS community receives a request for a report, the following steps w
 * Insert visualizations in template by TBD
 * Send Community Report to requester by TBD
 * If requester gave permission, add Community Report to our library on CHAOSS.community by TBD
-

--- a/community-handbook/community-report.md
+++ b/community-handbook/community-report.md
@@ -15,6 +15,7 @@ The Community Report processes have the following roles:
 
 * Requester -- Someone asking for a Community Report
 * Coordinator -- The CHAOSS contact person coordinating the creation and distribution of Community Reports
+* Software Operator -- A person who works with CHAOSS software to generate visualizations
 
 ## Requesting a Community Report
 
@@ -24,9 +25,12 @@ Anyone can fill out a form on the CHAOSS.community website. The form submits to 
 
 When the CHAOSS community receives a request for a report, the following steps will be taken:
 
-* TBD by TBD
-* Get visualizations from Augur by TBD
-* Get visualizations from Cauldron/GrimoireLab by TBD
-* Insert visualizations in the template by Coordinator
-* Send Community Report to the requester by Coordinator
-* If requester gave permission, add Community Report to our library on CHAOSS.community by Coordinator
+1) Someone makes a request
+2) Salesforce kicks off the ticket to our emails
+3) Vinod, build a new folder for the community request like what I have in the drive now.
+4) Vinod, place the SF ticket in the folder
+5) Sean and Georg, generate the graphs for the requested URL and place them into the appropriate folder. Ping Vinod when you're done
+6) Vinod, assemble the Community Report by placing the graphs into the .ai document. This will require a bit of sizing but I have the approximate sizes marked in the template. Make sure to maintain ratios. This will also require a little cropping of Augur images at the top to remove some icons that come with the graphs.
+7) Vinod, email the report (in PDF form) and the SF ticket to Elizabeth (cc me)
+8) Elizabeth, send the report and SF ticket back to the requestor.
+9) If the requestor said it's okay to post it online, I'll get it into the GH folder 

--- a/community-handbook/community-report.md
+++ b/community-handbook/community-report.md
@@ -28,5 +28,5 @@ When the CHAOSS community receives a request for a report, the following steps w
 * Get visualizations from Augur by TBD
 * Get visualizations from Cauldron/GrimoireLab by TBD
 * Insert visualizations in the template by Coordinator
-* Send Community Report to requester by TBD
+* Send Community Report to the requester by Coordinator
 * If requester gave permission, add Community Report to our library on CHAOSS.community by TBD

--- a/community-handbook/community-report.md
+++ b/community-handbook/community-report.md
@@ -27,6 +27,6 @@ When the CHAOSS community receives a request for a report, the following steps w
 * TBD by TBD
 * Get visualizations from Augur by TBD
 * Get visualizations from Cauldron/GrimoireLab by TBD
-* Insert visualizations in template by TBD
+* Insert visualizations in the template by Coordinator
 * Send Community Report to requester by TBD
 * If requester gave permission, add Community Report to our library on CHAOSS.community by TBD

--- a/community-handbook/community-report.md
+++ b/community-handbook/community-report.md
@@ -29,4 +29,4 @@ When the CHAOSS community receives a request for a report, the following steps w
 * Get visualizations from Cauldron/GrimoireLab by TBD
 * Insert visualizations in the template by Coordinator
 * Send Community Report to the requester by Coordinator
-* If requester gave permission, add Community Report to our library on CHAOSS.community by TBD
+* If requester gave permission, add Community Report to our library on CHAOSS.community by Coordinator

--- a/community-handbook/community-report.md
+++ b/community-handbook/community-report.md
@@ -1,0 +1,33 @@
+# Community Report
+
+The CHAOSS Community Report is a free service that the CHAOSS community provides to open source communities.
+
+## Goals
+
+* Create awareness for the CHAOSS project
+* Showcase the CHAOSS metrics and software
+* Get more communities interested in CHAOSS metrics and software
+* Grow the CHAOSS community
+
+## Roles
+
+The Communit Report processes have the following roles:
+
+* Requester -- Someone asking for a Community Report
+* Coordinator -- The CHAOSS contact person coordianting the creation and distribution of Community Reports
+
+## Requesting a Community Report
+
+Anyone can fill out a form on the CHAOSS.community website. The form submits to a Linux Foundation system. 
+
+## Generating a Community Report
+
+When the CHAOSS community receives a request for a report, the following steps will be taken:
+
+* TBD by TBD
+* Get visualizations from Augur by TBD
+* Get visualizations from Cauldron/GrimoireLab by TBD
+* Insert visualizations in template by TBD
+* Send Community Report to requester by TBD
+* If requester gave permission, add Community Report to our library on CHAOSS.community by TBD
+

--- a/community-handbook/community-report.md
+++ b/community-handbook/community-report.md
@@ -11,7 +11,7 @@ The CHAOSS Community Report is a free service that the CHAOSS community provides
 
 ## Roles
 
-The Communit Report processes have the following roles:
+The Community Report processes have the following roles:
 
 * Requester -- Someone asking for a Community Report
 * Coordinator -- The CHAOSS contact person coordianting the creation and distribution of Community Reports

--- a/community-handbook/community-report.md
+++ b/community-handbook/community-report.md
@@ -14,7 +14,7 @@ The CHAOSS Community Report is a free service that the CHAOSS community provides
 The Community Report processes have the following roles:
 
 * Requester -- Someone asking for a Community Report
-* Coordinator -- The CHAOSS contact person coordianting the creation and distribution of Community Reports
+* Coordinator -- The CHAOSS contact person coordinating the creation and distribution of Community Reports
 
 ## Requesting a Community Report
 


### PR DESCRIPTION
This PR is for adding a handbook page for describing the process CHAOSS follows for delivering the Community Report.