### PR TITLE
removing dot-slash notation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Governance
 CHAOSS community governance lives here:
 
-* [Community Handbook](./community-handbook/)
-* [Project Charter](./project-charter.md)
-* [Code of Conduct](./code-of-conduct.md)
-* [Google Summer of Code coordination](./GSoC-interest.md)
+* [Community Handbook](community-handbook)
+* [Project Charter](project-charter.md)
+* [Code of Conduct](code-of-conduct.md)
+* [Google Summer of Code coordination](GSoC-interest.md)
 
 ## How to contribute to this repository
 
-We follow the GitHub pull-request workflow. More details on how to contribute is in the [CONTRIBUTING.md](./CONTRIBUTING.md).
+We follow the GitHub pull-request workflow. More details on how to contribute is in the [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ### Maintainers of this repository
 

--- a/community-handbook/README.md
+++ b/community-handbook/README.md
@@ -10,11 +10,11 @@ If you are interested in helping with the community handbook, [#105](https://git
 ## Table of Content
 
 * [General](./)
-  - [Handbook Usage](./handbook-usage.md)
-  - [Roles and Responsibilities in the Community](./roles-responsibilities.md)
-* [CHAOSScast](./chaosscast.md) - Community Podcast
-* [CHAOSScon](./chaosscon.md)
-* [Community Report](./community-report.md)
-* [Metrics Release](./metrics-release.md)
-  - [Metrics Translations](./metrics-translations.md)
-* [Website](./website.md)
+  - [Handbook Usage](handbook-usage.md)
+  - [Roles and Responsibilities in the Community](roles-responsibilities.md)
+* [CHAOSScast](chaosscast.md) - Community Podcast
+* [CHAOSScon](chaosscon.md)
+* [Community Report](community-report.md)
+* [Metrics Release](metrics-release.md)
+  - [Metrics Translations](metrics-translations.md)
+* [Website](website.md)


### PR DESCRIPTION
Hi,
This PR is to maintain consistency with other repositories,
by removing the `./` notation from READMEs

Signed-off-by: ritik-malik <ritik18406@iiitd.ac.in>