### PR TITLE
self-nomination for Adeyinka Oresanya

### DIFF
--- a/elections/2026-GB/candidate-adeyinkaoresanya.md
+++ b/elections/2026-GB/candidate-adeyinkaoresanya.md
@@ -1,0 +1,36 @@
+-------------------------------------------------------------
+name: Adeyinka Oresanya
+
+ID: adeyinkaoresanya
+
+info:
+  - affiliation: Independent
+-------------------------------------------------------------
+
+## Background
+I work as a software developer. Over the past 4 years, I have actively contributed to CHAOSS across research, code development,
+community leadership, and DEI-focused initiatives. I currently serve as lead maintainer for the CHAOSS DEI Badging Program and 
+co-chair of the DEI Working Group, providing strategic direction and supporting the expansion of DEI Badging across open source events and projects.
+
+## My Contributions to CHAOSS
+
+- Co-chairing the DEI Working Group, providing strategic direction and driving actionable initiatives
+    - Leading efforts to increase the adoption of the Project Badging by badging 20 projects by the end of 2026.
+    - Leading efforts to refine DEI metrics used for the DEI badging program.
+- Serving as lead maintainer for the CHAOSS DEI [Badging website](https://github.com/badging/badging), [BadgingAPI](https://github.com/badging/BadgingAPI), and [event-diversity-and-inclusion](https://github.com/badging/event-diversity-and-inclusion) repositories.
+    - Leading ongoing refactoring efforts on the Badging API to reduce technical debt, improve overall architecture, and standardize backend patterns.
+    - Designed and implemented the [Badging Reviewer Spotlight](https://github.com/badging/event-diversity-and-inclusion?tab=readme-ov-file) to recognize and celebrate reviewer contributors (DEI-badgers).
+    - Designed [Architecture Decision Records](https://github.com/badging/BadgingAPI/tree/main/docs/ADR) to document the architecture design and integration permission decisions of the Badging API and guide future development efforts.
+
+- Serving as Badging Lead, overseeing peer-review process for the DEI Event Badging project
+    - Successfully issued 100+ Event DEI Badges and reduced application turnaround time.
+    - Providing technical support for Event Badging applicants when needed, improving application experience.
+- Led the CHAOSS Africa Developer Focus Group in facilitating weekly calls, driving code contributions, and guiding new contributors
+    - Implemented a long-standing feature for the Badging website through a 2-week pair programming sprint.
+    - Organised training workshops to sharpen the skills of developer contributors and increase their impact on CHAOSS projects.
+
+
+## Why I'm Running
+
+In the next two years, my vision is for CHAOSS to strengthen its impact on community health and sustainability in the global open source ecosystem by increasing the reach, relevance, and adoption of its metrics, tools, and resources. My focus will be on strengthening governance and advancing contributor success by creating clearer pathways for contributors to participate, grow, and lead within the community. I will leverage my technical skills and experience leading the DEI badging program to bring a practical, contributor-centered perspective to the board and support the growth and sustainability of the CHAOSS community.
+


### PR DESCRIPTION
Added `elections/2026-GB/candidate-adeyinkaoresanya.md` with detailed information about Adeyinka Oresanya, including background, CHAOSS contributions, and vision for CHAOSS to to formally indicate my intent to run for a seat on CHAOSS Governing Board