### PR TITLE
self-nomination for Divya Mohan

### DIFF
--- a/elections/2026-GB/candidate-divya-mohan0209.md
+++ b/elections/2026-GB/candidate-divya-mohan0209.md
@@ -1,13 +1,13 @@
+-------------------------------------------------------------
 name: Divya Mohan
 
 ID: divya-mohan0209
 
 info:
+  - affiliation: SUSE
+-------------------------------------------------------------
 
-Affiliation: SUSE
-My Contributions to CHAOSS
-
-Specific project/working group involvement:
+## My Contributions to CHAOSS
 
 - Restarted CHAOSS Asia in 2024 and have been leading the chapter ever since
   - Partnered with the following on-the-ground organisations in Asia for evangelising & cross-promotion during events
@@ -19,8 +19,9 @@ Specific project/working group involvement:
   - Created the open source communities database (https://chaoss.github.io/oscdb/)
 - Part of the DEI Badging program
 
-Why I'm Running
+
+## Why I'm Running
+
 As CHAOSS Asia chapter lead, Linux Foundation contributor in technical, governance, and leadership roles, and with a decade of engineering experience, I'm running for the Governing Board to bring my unique blend of technical depth and cultural insight.
 As a board member, I'll amplify our shared mission: measuring and fostering healthy, inclusive open source communities by championing underrepresented voices and ensuring our project's values reflect the global community it serves.
-
 

--- a/elections/2026-GB/candidate-dmohan.md
+++ b/elections/2026-GB/candidate-dmohan.md
@@ -1,6 +1,6 @@
 name: Divya Mohan
 
-ID: cdolfi
+ID: divya-mohan0209
 
 info:
 

--- a/elections/2026-GB/candidate-dmohan.md
+++ b/elections/2026-GB/candidate-dmohan.md
@@ -1,0 +1,26 @@
+name: Divya Mohan
+
+ID: cdolfi
+
+info:
+
+Affiliation: SUSE
+My Contributions to CHAOSS
+
+Specific project/working group involvement:
+
+- Restarted CHAOSS Asia in 2024 and have been leading the chapter ever since
+  - Partnered with the following on-the-ground organisations in Asia for evangelising & cross-promotion during events
+      -   C4GT
+      -   RSE Asia & Australia
+      -   Kaiyuanshe
+      -   FOSS India
+      -   OpenHQ (sister organisation of OpenUK)
+  - Created the open source communities database (https://chaoss.github.io/oscdb/)
+- Part of the DEI Badging program
+
+Why I'm Running
+As CHAOSS Asia chapter lead, Linux Foundation contributor in technical, governance, and leadership roles, and with a decade of engineering experience, I'm running for the Governing Board to bring my unique blend of technical depth and cultural insight.
+As a board member, I'll amplify our shared mission: measuring and fostering healthy, inclusive open source communities by championing underrepresented voices and ensuring our project's values reflect the global community it serves.
+
+


### PR DESCRIPTION
Added ~elections/2026-GB/candidate-dmohan.md~ elections/2026-GB/candidate-divya-mohan0209.md with detailed information about Divya Mohan, including background, CHAOSS contributions, and vision for CHAOSS to formally indicate my intent to run for a seat on the CHAOSS Governing Board