### PR TITLE
Fix cdolfi affiliation

### DIFF
--- a/elections/2026-GB/candidate-cdolfi.md
+++ b/elections/2026-GB/candidate-cdolfi.md
@@ -4,7 +4,7 @@ name: Cali Dolfi
 ID: cdolfi
 
 info:
-- Affiliation: Red Hat
+- affiliation: Red Hat
 
 -------------------------------------------------------------
 


### PR DESCRIPTION
There's a case mismatch in the YAML key `affiliation`, hence cdolfi's affiliation doesn't show up in Elekto.