### PR TITLE
Add new voters to the 2026 GB elections

### DIFF
--- a/elections/2026-GB/voters.yaml
+++ b/elections/2026-GB/voters.yaml
@@ -106,6 +106,7 @@ eligible_voters:
   - alberefe
   - alice-sowerby
   - aliok
+  - andrew
   - antcybersec
   - antoninbas
   - anusha975
@@ -210,6 +211,7 @@ eligible_voters:
   - saksham23467
   - samcunliffe
   - sarina
+  - sdavtaker
   - sduenas
   - seleneyang
   - sgoggins


### PR DESCRIPTION
Manually adds eligible voters that were missing from the list.